### PR TITLE
Add missing mesa/mesa-geo/matplotlib pkgs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ RUN pip uninstall pillow fiona -y && \
 				ipyleaflet \
 				ipywidgets \
 				keplergl \
+				mesa-geo \
+				mesa \
+				matplotlib \
 				jupyterlab==2.3.1 \
 				shapely==2.0.0 \
 				pyshp==2.3.1 \


### PR DESCRIPTION
arcgis_test notebook missing modules mesa_geo and mesa. This resolves those missing dependencies.

Previous merge only included keplergl. 